### PR TITLE
Change how files from navbar list are handled

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ app.get('/edit/:project', function(req, res, next) {
             res.render('edit', {project:dirname});
         } else {
             console.log('file is on server, but needs to be user submitted');
-            res.render('index');
+            res.redirect('/');
         }
     } else {
         console.log('open temp directory specified');

--- a/index.js
+++ b/index.js
@@ -21,8 +21,23 @@ app.get('/', function(req, res) {
 
 app.use('/finished', express.static(__dirname + '/finished/'));
 
-app.get('/edit/:project', function(req, res) {
-    res.render('edit', {project:req.params.project});
+app.get('/edit/:project', function(req, res, next) {
+    var filename = req.params.project;
+    if (filename[filename.length-4] == '.') {
+        var dirname = filename.slice(0,-4);
+        console.log(path.join(__dirname, 'test', dirname));
+        if (fs.existsSync(path.join(__dirname, 'test', dirname))) {
+            console.log('filename is a directory that already exists');
+            res.render('edit', {project:dirname});
+        } else {
+            console.log('file is on server, but needs to be user submitted');
+            res.render('index');
+        }
+    } else {
+        console.log('open temp directory specified');
+        res.render('edit', {project:filename});
+    }
+
 });
 
 app.delete('/:project', function(req, res) {
@@ -228,7 +243,6 @@ app.post('/upload', upload.single('file'), function(req,res, next) {
         //folder already exists
         res.redirect('/edit/' + foldername);
     }
-    
 });
 
 /********************************************************************/


### PR DESCRIPTION
When the user clicked a filename from the navbar list, original behavior
was to erroneously go to the edit page, without any processing. This
would show the user a blank page.

Now, clicking a filename will first check if a folder path with
the same name as the file already exists. If it does, the site will
navigate to the edit page. If it doesn't, a message is printed to
console and the index page is refreshed.

This is only an issue while example files are stored on the server.
Other options are to remove the example files or only show directories
in the navbar list.

Ideally, a future iteration will allow processing of an example pdf by
simply clicking on it.